### PR TITLE
add license field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,5 +16,6 @@
         "underscore" : ">=1.1.7 < 2.0.0"
     },
     "engine" : "node >= 0.5.1",
-    "main": "./backuptweets"
+    "main": "./backuptweets",
+    "license": "MIT"
 }


### PR DESCRIPTION
prevents the `npm WARN backuptweets@0.1.0 No license field.` console output